### PR TITLE
feat(sort-authors): Add `-b/--sorted` flag to sort authors alphabetically.

### DIFF
--- a/commits
+++ b/commits
@@ -3,6 +3,7 @@
 set -e
 
 PARAMS=""
+SORTED=cat
 
 while (( "$#" )); do
   case "$1" in
@@ -24,6 +25,10 @@ while (( "$#" )); do
       ;;
     -u|--authors)
       SHOW_AUTHORS=true
+      shift
+      ;;
+    -b|--sorted)
+      SORTED=sort
       shift
       ;;
     -h|--help)
@@ -88,11 +93,11 @@ then
   exit
 elif [[ ${SHOW_AUTHORS} && ${PREFIX} ]]
 then
-  git log --since=${DATE_SINCE} | grep Co-authored-by: | awk '!x[$0]++' | ${GNU_COMMAND_PREFIX}sed -r "s/^\s*//"
+  git log --since=${DATE_SINCE} | grep Co-authored-by: | awk '!x[$0]++' | ${GNU_COMMAND_PREFIX}sed -r "s/^\s*//" | ${SORTED}
   exit
 elif [[ ${SHOW_AUTHORS} ]]
 then
-  git log --since=${DATE_SINCE} | grep Co-authored-by: | ${GNU_COMMAND_PREFIX}sed -r  "s/^\s*Co\-authored\-by\:\s*(.*)/\1/" | awk '!x[$0]++'
+  git log --since=${DATE_SINCE} | grep Co-authored-by: | ${GNU_COMMAND_PREFIX}sed -r  "s/^\s*Co\-authored\-by\:\s*(.*)/\1/" | awk '!x[$0]++' | ${SORTED}
   exit
 fi
 


### PR DESCRIPTION
* If flag is used alongside --authors, `sort` is applied to the end of the command to sort the authors alphabetically.
* If flag is not set, the command is pipes to `cat` instead, which effectively does nothing to the output.
* This also works in combination with the `--prefix` flag.